### PR TITLE
[FEAT] 카테고리 버튼 컴포넌트 퍼블리싱

### DIFF
--- a/src/components/button/categoryItemBtn/CategoryItemBtn.tsx
+++ b/src/components/button/categoryItemBtn/CategoryItemBtn.tsx
@@ -1,0 +1,20 @@
+import { defaultBtnStyle, BtnSizeMap } from './CategoryItemBtnStyle';
+import { ReactElement } from 'react';
+
+interface CategoryItemBtnProps {
+	btnText: string;
+	onClick?: () => void;
+	size: 'small' | 'medium';
+	icon: ReactElement; // svg 컴포넌트, icon={<Icon />} 이런식으로 svg컴포넌트를 넘겨주기
+}
+
+const CategoryItemBtn = ({ btnText, onClick, size, icon }: CategoryItemBtnProps) => {
+	return (
+		<button css={[defaultBtnStyle, BtnSizeMap[size]]} onClick={onClick}>
+			{icon}
+			{btnText}
+		</button>
+	);
+};
+
+export default CategoryItemBtn;

--- a/src/components/button/categoryItemBtn/CategoryItemBtnStyle.ts
+++ b/src/components/button/categoryItemBtn/CategoryItemBtnStyle.ts
@@ -1,0 +1,41 @@
+import { css } from '@emotion/react';
+
+export const defaultBtnStyle = css`
+	display: flex;
+	align-items: center;
+	justify-content: flex-start;
+
+	color: black;
+
+	background-color: white;
+	border: none;
+
+	:hover {
+		color: red;
+	}
+`;
+
+export const SmallBtnContainerStyle = css`
+	gap: 0.3rem;
+	box-sizing: border-box;
+	width: 17rem;
+	height: 2.5rem;
+	padding: 0 0.4rem;
+
+	border-radius: 6px;
+`;
+
+export const MediumBtnContainerStyle = css`
+	gap: 0.6rem;
+	box-sizing: border-box;
+	width: 19.3rem;
+	height: 3rem;
+	padding: 0 0.6rem;
+
+	border-radius: 6px;
+`;
+
+export const BtnSizeMap = {
+	small: SmallBtnContainerStyle,
+	medium: MediumBtnContainerStyle,
+};


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 관련 이슈 🛰️
> 해결한 이슈 번호를 작성해주세요
close #21

## 작업 내용 🧑‍💻
> 작업한 내용을 간략히 작성해주세요
<!-- 예시:
- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 로그아웃 기능 구현 및 UI 수정
-->
- 카테코리 아이템 버튼 퍼블리싱을 구현하였습니다.

## PR 포인트 🗯️
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->

```
interface CategoryItemBtnProps {
	btnText: string;
	onClick?: () => void;
	size: 'small' | 'medium';
	icon: ReactElement; // svg 컴포넌트, icon={<Icon />} 이런식으로 svg컴포넌트를 넘겨주기
}
```
- icon의 타입을 ReactElement로 설정하였는데 나중에 svg컴포넌트를 생성하면 `React.FC<SVGProps<SVGSVGElement>>`로 타입을 정의해서 svg 컴포넌트만 허용하게 할 수 있습니다. 현재는 스타일 컴포넌트를 넘겨서 아이콘 처럼 보이게 하기 위해서 ReactElement로 설정하였습니다.
- 주석은 나중에 해당 컴포넌트를 사용하는 사람의 이해를 돕기 위해 작성하였는데 지워도 된다고 생각하시면 의견 남겨주세요!
- 아직 색상과 폰트 적용은 하지 않았습니다.



## 알게된 점 🚀
> 기록하며 개발하기!
<!-- 예시:
- React Query의 staleTime 설정 방법
![Nov-19-2024 02-37-55](https://github.com/user-attachments/assets/f0f78a40-448d-48ea-b53e-b08ee652a25e)

-->
- 

## 참고 자료 📖 (선택)
> 참고했던 문서들 공유하기!
<!-- 예시:
- React Query의 staleTime 설정 방법 : https://velog.io/@oimne/React-Query-staleTime%EA%B3%BC-cacheTime-%EB%8B%A4%EB%A3%A8%EA%B8%B0
-->
- 


## 스크린샷 📸 (선택)
<!-- 작업한 내용의 스크린샷을 첨부하고 싶다면 작성하세요 -->
![Nov-19-2024 02-37-55](https://github.com/user-attachments/assets/99a6b2de-d8e6-4a05-9c57-e962921db379)

실제 디자인

![image](https://github.com/user-attachments/assets/60c4d1af-fc09-4ce1-9964-f11b7d21c499)
