### PR TITLE
[FEAT] 연관상품 (ProductList) 띄우기

### DIFF
--- a/src/components/product/ProductCard.tsx
+++ b/src/components/product/ProductCard.tsx
@@ -1,7 +1,7 @@
 import { IcArrowrightGray12 } from '@assets/icons';
 
 import FreeTag from './FreeTag';
-import { couponBtnStyle, imageContainer, imageStyle, priceContainer, productContainer, productDiscountStyle, productInfoContainer, productInfoWrapper, productNameStyle, productPriceStyle, productWonStyle, tagContainer } from './ProductCardStyle';
+import { couponBtnStyle, imageContainer, imageStyle, priceContainer, productContainer, productDiscountStyle, productInfoContainer, productInfoWrapper, productNameStyle, productPriceStyle, productWonStyle, productWrapper, tagContainer } from './ProductCardStyle';
 
 interface ProductProps {
     image: string;
@@ -13,25 +13,26 @@ interface ProductProps {
 
 const ProductCard = ({ image, name, price, discountRate, hasCoupon }: ProductProps) => (
         <section css={productContainer}>
-            <article css={imageContainer}>
-                <img css={imageStyle} src={image} alt={name} />
-            </article>
-            <article css={productInfoContainer}>
-                <article css={productInfoWrapper}>
-                    <p css={productNameStyle}>{name}</p>
-                    <div css={priceContainer}>
-                        <p css={productWonStyle}>₩</p>
-                        <p css={productPriceStyle}>{price.toLocaleString()}</p>
-                        <span css={productDiscountStyle}>{discountRate}%</span>
-                    </div>
-                </article>               
-                <article css={tagContainer}>
-                    <FreeTag text='무료 배송' color='red'/>
-                    <FreeTag text='무료 반품' color='gray'/>
+            <article css={productWrapper}>
+                <article css={imageContainer}>
+                    <img css={imageStyle} src={image} alt={name} />
                 </article>
+                <article css={productInfoContainer}>
+                    <article css={productInfoWrapper}>
+                        <p css={productNameStyle}>{name}</p>
+                        <div css={priceContainer}>
+                            <p css={productWonStyle}>₩</p>
+                            <p css={productPriceStyle}>{price.toLocaleString()}</p>
+                            <span css={productDiscountStyle}>{discountRate}%</span>
+                        </div>
+                    </article>               
+                    <article css={tagContainer}>
+                        <FreeTag text='무료 배송' color='red'/>
+                        <FreeTag text='무료 반품' color='gray'/>
+                    </article>
+                </article>
+                {hasCoupon && <button css={couponBtnStyle}>쿠폰 받기<IcArrowrightGray12/></button>}
             </article>
-            {hasCoupon && <button css={couponBtnStyle}>쿠폰 받기<IcArrowrightGray12/></button>}
-
         </section>
 );
 

--- a/src/components/product/ProductCard.tsx
+++ b/src/components/product/ProductCard.tsx
@@ -1,7 +1,7 @@
 import { IcArrowrightGray12 } from '@assets/icons';
 
 import FreeTag from './FreeTag';
-import { couponBtnStyle, imageContainer, imageStyle, priceContainer, productContainer, productDiscountStyle, productInfoContainer, productInfoWrapper, productNameStyle, productPriceStyle, productWonStyle, tagContainer } from './ProductCardStyle';
+import { couponBtnStyle, imageContainer, imageStyle, priceContainer, productContainer, productDiscountStyle, productInfoContainer, productInfoWrapper, productNameStyle, productPriceStyle, productWonStyle, productWrapper, tagContainer } from './ProductCardStyle';
 import StarBtn from '@components/button/starBtn/StarBtn';
 
 interface ProductProps {
@@ -16,26 +16,27 @@ interface ProductProps {
 
 const ProductCard = ({ image, name, price, discountRate, hasCoupon = false, rating, reviewCount }: ProductProps) => (
         <article css={productContainer}>
-            <div css={imageContainer}>
-                <img css={imageStyle} src={image} alt={name} />
+            <div css={productWrapper}>
+                <div css={imageContainer}>
+                    <img css={imageStyle} src={image} alt={name} />
+                </div>
+                <div css={productInfoContainer}>
+                    <div css={productInfoWrapper}>
+                        <p css={productNameStyle}>{name}</p>
+                        <StarBtn rating={rating} reviewCount={reviewCount} isRatingVisible={false} />
+                        <div css={priceContainer}>
+                            <span css={productWonStyle}>₩</span>
+                            <span css={productPriceStyle}>{price.toLocaleString()}</span>
+                            <span css={productDiscountStyle}>{discountRate}%</span>
+                        </div>
+                    </div>               
+                    <ul css={tagContainer}>
+                        <li><FreeTag text='무료 배송' color='red'/></li>
+                        <li><FreeTag text='무료 반품' color='gray'/></li>
+                    </ul>
+                </div>
+                {hasCoupon && <button css={couponBtnStyle}>쿠폰 받기<IcArrowrightGray12/></button>}
             </div>
-            <div css={productInfoContainer}>
-                <div css={productInfoWrapper}>
-                    <p css={productNameStyle}>{name}</p>
-                    <StarBtn rating={rating} reviewCount={reviewCount} isRatingVisible={false} />
-                    <div css={priceContainer}>
-                        <span css={productWonStyle}>₩</span>
-                        <span css={productPriceStyle}>{price.toLocaleString()}</span>
-                        <span css={productDiscountStyle}>{discountRate}%</span>
-                    </div>
-                </div>               
-                <ul css={tagContainer}>
-                    <li><FreeTag text='무료 배송' color='red'/></li>
-                    <li><FreeTag text='무료 반품' color='gray'/></li>
-                </ul>
-            </div>
-            {hasCoupon && <button css={couponBtnStyle}>쿠폰 받기<IcArrowrightGray12/></button>}
-
         </article>
 );
 

--- a/src/components/product/ProductCardList.tsx
+++ b/src/components/product/ProductCardList.tsx
@@ -29,8 +29,8 @@ const ProductCardList = ({ products }: ProductCardListProps ) => {
                         price={product.price}
                         discountRate={product.discountRate}
                         hasCoupon={product.hasCoupon}
-                        rating={3.5}
-                        reviewCount={123}
+                        rating={product.rating}
+                        reviewCount={product.reviewCount}
                     />
                 ))}
             </article>

--- a/src/components/product/ProductCardList.tsx
+++ b/src/components/product/ProductCardList.tsx
@@ -17,11 +17,11 @@ interface ProductCardListProps {
 
 const ProductCardList = ({ products }: ProductCardListProps ) => {
     return (
-        <main css={relatedProductsContainer}>
-            <section css={relatedProductsHeaderStyle}>
+        <section css={relatedProductsContainer}>
+            <div css={relatedProductsHeaderStyle}>
                 <p css={relatedProductsStyle}>연관 상품</p>
-            </section>
-            <section css={productListContainer}>
+            </div>
+            <article css={productListContainer}>
                 {products.map((product) => (
                     <ProductCard
                         image={product.image}
@@ -33,8 +33,8 @@ const ProductCardList = ({ products }: ProductCardListProps ) => {
                         reviewCount={123}
                     />
                 ))}
-            </section>
-        </main>
+            </article>
+        </section>
     );
 };
 

--- a/src/components/product/ProductCardList.tsx
+++ b/src/components/product/ProductCardList.tsx
@@ -1,0 +1,37 @@
+import ProductCard from './ProductCard';
+import { productListContainer, relatedProductsContainer, relatedProductsHeaderStyle, relatedProductsStyle } from './ProductCardListStyle';
+
+interface Product {
+    image: string;
+    name: string;
+    price: number;
+    discountRate: number;
+    hasCoupon?: boolean;
+}
+
+interface ProductCardListProps {
+    products: Product[];
+}
+
+const ProductCardList = ({ products }: ProductCardListProps ) => {
+    return (
+        <main css={relatedProductsContainer}>
+            <section css={relatedProductsHeaderStyle}>
+                <p css={relatedProductsStyle}>연관 상품</p>
+            </section>
+            <section css={productListContainer}>
+                {products.map((product) => (
+                    <ProductCard
+                        image={product.image}
+                        name={product.name}
+                        price={product.price}
+                        discountRate={product.discountRate}
+                        hasCoupon={product.hasCoupon}
+                    />
+                ))}
+            </section>
+        </main>
+    );
+};
+
+export default ProductCardList;

--- a/src/components/product/ProductCardList.tsx
+++ b/src/components/product/ProductCardList.tsx
@@ -7,6 +7,8 @@ interface Product {
     price: number;
     discountRate: number;
     hasCoupon?: boolean;
+    rating: number;
+    reviewCount: number;
 }
 
 interface ProductCardListProps {
@@ -27,6 +29,8 @@ const ProductCardList = ({ products }: ProductCardListProps ) => {
                         price={product.price}
                         discountRate={product.discountRate}
                         hasCoupon={product.hasCoupon}
+                        rating={3.5}
+                        reviewCount={123}
                     />
                 ))}
             </section>

--- a/src/components/product/ProductCardListStyle.ts
+++ b/src/components/product/ProductCardListStyle.ts
@@ -1,0 +1,26 @@
+import { Theme, css } from '@emotion/react';
+
+export const relatedProductsContainer = css`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 136.6rem;
+`;
+
+export const relatedProductsHeaderStyle = css`
+    display: flex;
+    align-items: center;
+    width: 127.7rem;
+    height: 4.6rem;
+`;
+
+export const relatedProductsStyle = (theme: Theme) => css`
+    ${theme.fonts.kor.titleBold20};
+`;
+
+export const productListContainer = css`
+    display: flex;
+    flex-wrap: wrap;
+    gap: 13px;
+    width: 127.7rem;
+`;

--- a/src/components/product/ProductCardListStyle.ts
+++ b/src/components/product/ProductCardListStyle.ts
@@ -21,6 +21,6 @@ export const relatedProductsStyle = (theme: Theme) => css`
 export const productListContainer = css`
     display: flex;
     flex-wrap: wrap;
-    gap: 13px;
+    gap: 24px 13px;
     width: 127.7rem;
 `;

--- a/src/components/product/ProductCardListStyle.ts
+++ b/src/components/product/ProductCardListStyle.ts
@@ -4,7 +4,7 @@ export const relatedProductsContainer = css`
     display: flex;
     flex-direction: column;
     align-items: center;
-    width: 136.6rem;
+
 `;
 
 export const relatedProductsHeaderStyle = css`
@@ -21,6 +21,6 @@ export const relatedProductsStyle = (theme: Theme) => css`
 export const productListContainer = css`
     display: flex;
     flex-wrap: wrap;
-    gap: 24px 13px;
+    gap: 2.4rem 1.3rem;
     width: 127.7rem;
 `;

--- a/src/components/product/ProductCardStyle.ts
+++ b/src/components/product/ProductCardStyle.ts
@@ -26,7 +26,7 @@ export const productContainer = (theme: Theme) => css`
 export const productWrapper = (theme: Theme) => css`
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 1.2rem;
     align-items: center;
     width: 20.2rem;
     
@@ -52,13 +52,13 @@ export const imageStyle = css`
 export const productInfoContainer = css`
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 0.8rem;
 `;
 
 export const productInfoWrapper = css`
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: 0.4rem;
 `;
 
 export const productNameStyle = (theme: Theme) => css`
@@ -92,12 +92,12 @@ export const productDiscountStyle = (theme: Theme) => css`
 
 export const tagContainer = css`
     display: flex;
-    gap: 10px;
+    gap: 1rem;
 `;
 
 export const couponBtnStyle = (theme: Theme) => css`
     display: flex;
-    gap: 8px;
+    gap: 0.8rem;
     align-items: center;
     justify-content: space-between;
     width: 100%;

--- a/src/components/product/ProductCardStyle.ts
+++ b/src/components/product/ProductCardStyle.ts
@@ -3,6 +3,27 @@ import { Theme, css } from '@emotion/react';
 export const productContainer = (theme: Theme) => css`
 
     position: relative;
+    width: 20.2rem;
+    height: fit-content;
+    
+    background-color: ${theme.colors.white};
+    border-radius: 12px;
+
+    &:hover {
+        z-index: 1;
+
+        box-shadow: 0 6px 12px 0 rgb(0 0 0 / 12%), 0 4px 8px 0 rgb(0 0 0 / 8%), 0 0 4px 0 rgb(0 0 0 / 8%);
+        transform: scale(1.13, 1.065);
+        transform-origin: top center; /* 상단의 시작 지점을 고정 */
+        border-radius: 16px;
+    }
+
+    &:hover > * {
+        transform: scale(0.87, 0.935); /* 내부 요소 축소 */
+    }
+`;
+
+export const productWrapper = (theme: Theme) => css`
     display: flex;
     flex-direction: column;
     gap: 12px;
@@ -11,15 +32,6 @@ export const productContainer = (theme: Theme) => css`
     
     background-color: ${theme.colors.white};
     border-radius: 12px;
-
-    &:hover {
-        width: 22.8rem;
-        padding: 1.3rem;
-
-        box-shadow: 0 6px 12px 0 rgb(0 0 0 / 12%), 0 4px 8px 0 rgb(0 0 0 / 8%), 0 0 4px 0 rgb(0 0 0 / 8%);
-        transform-origin: top center; /* 상단의 시작 지점을 고정 */
-        border-radius: 16px;
-    }
 `;
 
 export const imageContainer = css`


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 관련 이슈 🛰️
> 해결한 이슈 번호를 작성해주세요
close #42 

## 작업 내용 🧑‍💻
> 작업한 내용을 간략히 작성해주세요
<!-- 예시:
- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 로그아웃 기능 구현 및 UI 수정
-->
- 상품 컴포넌트 만든것 활용해서 연관상품 리스트 띄우기
- 호버 시 기존 컴포넌트 위치 기준으로 중앙-상단 정렬
- 전체 화면은 기본 100%로 두고, 연관상품을 바로 위에서 감싸는 박스 크기는 디자인 수치대로 적용하여 가운데 정렬 했습니다.

## PR 포인트 🗯️
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 더 좋은 방법이 있다면 알려주세요!

## 알게된 점 🚀
> 기록하며 개발하기!
<!-- 예시:
- React Query의 staleTime 설정 방법
-->
- `transform: scale()` 을 하면 해당 요소 안의 자식들도 모두 확장/축소 됨

## 참고 자료 📖 (선택)
> 참고했던 문서들 공유하기!
<!-- 예시:
- React Query의 staleTime 설정 방법 : https://velog.io/@oimne/React-Query-staleTime%EA%B3%BC-cacheTime-%EB%8B%A4%EB%A3%A8%EA%B8%B0
-->
- 호버 효과 트러블슈팅 아티클 작성 예정


## 스크린샷 📸 (선택)
<!-- 작업한 내용의 스크린샷을 첨부하고 싶다면 작성하세요 -->

https://github.com/user-attachments/assets/b85f2cba-7fe2-4674-b835-55f08408842a

