### PR TITLE
[FIX] 상품 컴포넌트 크기 조정

### DIFF
--- a/src/components/product/ProductCard.tsx
+++ b/src/components/product/ProductCard.tsx
@@ -46,9 +46,9 @@ const ProductCard = ({
 			<div css={imageContainer(width)}>
 				<img css={imageStyle} src={image} alt={name} />
 			</div>
-			<div css={productInfoContainer(hoverLarge)}>
+			<div css={productInfoContainer(width, hoverLarge)}>
 				<div css={productInfoWrapper}>
-					<p css={productNameStyle}>{name}</p>
+					<span css={productNameStyle}>{name}</span>
 					<StarBtn rating={rating} reviewCount={reviewCount} isRatingVisible={false} />
 					<div css={priceContainer}>
 						<span css={productWonStyle}>₩</span>

--- a/src/components/product/ProductCard.tsx
+++ b/src/components/product/ProductCard.tsx
@@ -1,43 +1,78 @@
 import { IcArrowrightGray12 } from '@assets/icons';
 
 import FreeTag from './FreeTag';
-import { couponBtnStyle, imageContainer, imageStyle, priceContainer, productContainer, productDiscountStyle, productInfoContainer, productInfoWrapper, productNameStyle, productPriceStyle, productWonStyle, productWrapper, tagContainer } from './ProductCardStyle';
+import {
+	couponBtnStyle,
+	imageContainer,
+	imageStyle,
+	priceContainer,
+	productContainer,
+	productDiscountStyle,
+	productInfoContainer,
+	productInfoWrapper,
+	productNameStyle,
+	productPriceStyle,
+	productWonStyle,
+	productWrapper,
+	tagContainer,
+} from './ProductCardStyle';
 import StarBtn from '@components/button/starBtn/StarBtn';
 
 interface ProductProps {
-    image: string;
-    name: string;
-    price: number;
-    discountRate: number;
-    hasCoupon?: boolean;
-    rating: number;
-    reviewCount: number;
+	image: string;
+	name: string;
+	price: number;
+	discountRate: number;
+	hasCoupon?: boolean;
+	rating: number;
+	reviewCount: number;
+	width?: string;
+	hoverLarge?: boolean;
 }
 
-const ProductCard = ({ image, name, price, discountRate, hasCoupon = false, rating, reviewCount }: ProductProps) => (
-        <article css={productContainer}>
-            <div css={productWrapper}>
-                <div css={imageContainer}>
-                    <img css={imageStyle} src={image} alt={name} />
-                </div>
-                <div css={productInfoContainer}>
-                    <div css={productInfoWrapper}>
-                        <p css={productNameStyle}>{name}</p>
-                        <StarBtn rating={rating} reviewCount={reviewCount} isRatingVisible={false} />
-                        <div css={priceContainer}>
-                            <span css={productWonStyle}>₩</span>
-                            <span css={productPriceStyle}>{price.toLocaleString()}</span>
-                            <span css={productDiscountStyle}>{discountRate}%</span>
-                        </div>
-                    </div>               
-                    <ul css={tagContainer}>
-                        <li><FreeTag text='무료 배송' color='red'/></li>
-                        <li><FreeTag text='무료 반품' color='gray'/></li>
-                    </ul>
-                </div>
-                {hasCoupon && <button css={couponBtnStyle}>쿠폰 받기<IcArrowrightGray12/></button>}
-            </div>
-        </article>
+const ProductCard = ({
+	image,
+	name,
+	price,
+	discountRate,
+	hasCoupon = false,
+	rating,
+	reviewCount,
+	width = '20.2rem',
+	hoverLarge = true,
+}: ProductProps) => (
+	<article css={(theme) => productContainer(theme, width, hoverLarge)}>
+		<div css={productWrapper}>
+			<div css={imageContainer(width)}>
+				<img css={imageStyle} src={image} alt={name} />
+			</div>
+			<div css={productInfoContainer(hoverLarge)}>
+				<div css={productInfoWrapper}>
+					<p css={productNameStyle}>{name}</p>
+					<StarBtn rating={rating} reviewCount={reviewCount} isRatingVisible={false} />
+					<div css={priceContainer}>
+						<span css={productWonStyle}>₩</span>
+						<span css={productPriceStyle}>{price.toLocaleString()}</span>
+						<span css={productDiscountStyle}>{discountRate}%</span>
+					</div>
+				</div>
+				<ul css={tagContainer}>
+					<li>
+						<FreeTag text="무료 배송" color="red" />
+					</li>
+					<li>
+						<FreeTag text="무료 반품" color="gray" />
+					</li>
+				</ul>
+			</div>
+			{hasCoupon && (
+				<button css={couponBtnStyle}>
+					쿠폰 받기
+					<IcArrowrightGray12 />
+				</button>
+			)}
+		</div>
+	</article>
 );
 
 export default ProductCard;

--- a/src/components/product/ProductCard.tsx
+++ b/src/components/product/ProductCard.tsx
@@ -66,10 +66,12 @@ const ProductCard = ({
 				</ul>
 			</div>
 			{hasCoupon && (
-				<button css={couponBtnStyle}>
-					쿠폰 받기
-					<IcArrowrightGray12 />
-				</button>
+                <div css={(theme) => couponBtnStyle(theme, hoverLarge)}>
+                    <button>
+                        쿠폰 받기
+                        <IcArrowrightGray12 />
+                    </button>
+                </div>
 			)}
 		</div>
 	</article>

--- a/src/components/product/ProductCardStyle.ts
+++ b/src/components/product/ProductCardStyle.ts
@@ -109,19 +109,23 @@ export const tagContainer = css`
 	gap: 1rem;
 `;
 
-export const couponBtnStyle = (theme: Theme) => css`
-	display: flex;
-	gap: 0.8rem;
-	align-items: center;
-	justify-content: space-between;
+export const couponBtnStyle = (theme: Theme, hoverLarge: boolean) => css`
+	button {
+		display: flex;
+		gap: 0.8rem;
+		align-items: center;
+		justify-content: space-between;
+		width: 100%;
+		height: 2.9rem;
+		padding: 0.8rem 1.2rem;
+
+		color: ${theme.colors.gray9};
+		${theme.fonts.kor.captionBold11};
+
+		background-color: ${theme.colors.gray2};
+		border: 0;
+		border-radius: 12px;
+	}
 	width: 100%;
-	height: 2.9rem;
-	padding: 0.8rem 1.2rem;
-
-	color: ${theme.colors.gray9};
-	${theme.fonts.kor.captionBold11};
-
-	background-color: ${theme.colors.gray2};
-	border: 0;
-	border-radius: 12px;
+	${!hoverLarge && `padding: 0 1.6rem;`}
 `;

--- a/src/components/product/ProductCardStyle.ts
+++ b/src/components/product/ProductCardStyle.ts
@@ -1,115 +1,127 @@
 import { Theme, css } from '@emotion/react';
 
-export const productContainer = (theme: Theme) => css`
+export const productContainer = (theme: Theme, width: string, hoverLarge: boolean) => css`
+	position: relative;
+	width: ${width};
+	height: fit-content;
 
-    position: relative;
-    width: 20.2rem;
-    height: fit-content;
-    
-    background-color: ${theme.colors.white};
-    border-radius: 12px;
+	background-color: ${theme.colors.white};
+	border-radius: ${hoverLarge ? '12px' : '16px'};
 
-    &:hover {
-        z-index: 1;
+	&:hover {
+		z-index: 1;
 
-        box-shadow: 0 6px 12px 0 rgb(0 0 0 / 12%), 0 4px 8px 0 rgb(0 0 0 / 8%), 0 0 4px 0 rgb(0 0 0 / 8%);
-        transform: scale(1.13, 1.065);
-        transform-origin: top center; /* 상단의 시작 지점을 고정 */
-        border-radius: 16px;
-    }
+		box-shadow:
+			0 6px 12px 0 rgb(0 0 0 / 12%),
+			0 4px 8px 0 rgb(0 0 0 / 8%),
+			0 0 4px 0 rgb(0 0 0 / 8%);
+		${hoverLarge
+			? `
+            transform: scale(1.13, 1.065);
+            transform-origin: top center; /* 상단의 시작 지점을 고정 */
+            border-radius: 16px;
+            `
+			: `
+            padding-bottom: 1.6rem;
+        `}
+	}
 
-    &:hover > * {
-        transform: scale(0.87, 0.935); /* 내부 요소 축소 */
-    }
+	&:hover > * {
+		${hoverLarge
+			? `
+            transform: scale(0.87, 0.935); /* 내부 요소 축소 */
+            `
+			: ''}
+	}
 `;
 
 export const productWrapper = (theme: Theme) => css`
-    display: flex;
-    flex-direction: column;
-    gap: 1.2rem;
-    align-items: center;
-    width: 20.2rem;
-    
-    background-color: ${theme.colors.white};
-    border-radius: 12px;
+	display: flex;
+	flex-direction: column;
+	gap: 1.2rem;
+	align-items: center;
+
+	/* width: ; */
+
+	background-color: ${theme.colors.white};
+	border-radius: 12px;
 `;
 
-export const imageContainer = css`
-    position: relative;
-    width: 20.2rem;
-    height: 20.2rem;
-    overflow: hidden;
+export const imageContainer = (width: string) => css`
+	position: relative;
+	width: ${width};
+	height: ${width};
+	overflow: hidden;
 
-    border-radius: 12px;
+	border-radius: 12px;
 `;
 
 export const imageStyle = css`
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
 `;
 
-export const productInfoContainer = css`
-    display: flex;
-    flex-direction: column;
-    gap: 0.8rem;
+export const productInfoContainer = (hoverLarge: boolean) => css`
+	display: flex;
+	flex-direction: column;
+	gap: 0.8rem;
+	${!hoverLarge && `padding: 0 1.6rem;`}
 `;
 
 export const productInfoWrapper = css`
-    display: flex;
-    flex-direction: column;
-    gap: 0.4rem;
+	display: flex;
+	flex-direction: column;
+	gap: 0.4rem;
 `;
 
 export const productNameStyle = (theme: Theme) => css`
-    ${theme.fonts.eng.bodyMedium13};
-    color: ${theme.colors.gray9};
+	${theme.fonts.eng.bodyMedium13};
+	color: ${theme.colors.gray9};
 `;
 
 export const priceContainer = css`
-    display: flex;
+	display: flex;
 `;
 
 export const productWonStyle = (theme: Theme) => css`
-    ${theme.fonts.eng.captionBold10};
-    display: flex;
-    align-items: end;
+	${theme.fonts.eng.captionBold10};
+	display: flex;
+	align-items: end;
 
-    color: ${theme.colors.gray9};
+	color: ${theme.colors.gray9};
 `;
 
 export const productPriceStyle = (theme: Theme) => css`
-    ${theme.fonts.eng.titleBold18};
-    color: ${theme.colors.gray9};
+	${theme.fonts.eng.titleBold18};
+	color: ${theme.colors.gray9};
 `;
 
 export const productDiscountStyle = (theme: Theme) => css`
-    ${theme.fonts.eng.titleBold18};
-    margin-left: 0.5rem;
+	${theme.fonts.eng.titleBold18};
+	margin-left: 0.5rem;
 
-    color: ${theme.colors.brandPrimary};
+	color: ${theme.colors.brandPrimary};
 `;
 
 export const tagContainer = css`
-    display: flex;
-    gap: 1rem;
+	display: flex;
+	gap: 1rem;
 `;
 
 export const couponBtnStyle = (theme: Theme) => css`
-    display: flex;
-    gap: 0.8rem;
-    align-items: center;
-    justify-content: space-between;
-    width: 100%;
-    height: 2.9rem;
-    padding: 0.8rem 1.2rem;
+	display: flex;
+	gap: 0.8rem;
+	align-items: center;
+	justify-content: space-between;
+	width: 100%;
+	height: 2.9rem;
+	padding: 0.8rem 1.2rem;
 
+	color: ${theme.colors.gray9};
+	${theme.fonts.kor.captionBold11};
 
-    color: ${theme.colors.gray9};
-    ${theme.fonts.kor.captionBold11};
-
-
-    background-color: ${theme.colors.gray2};
-    border: 0;
-    border-radius: 12px;
-`
+	background-color: ${theme.colors.gray2};
+	border: 0;
+	border-radius: 12px;
+`;

--- a/src/components/product/ProductCardStyle.ts
+++ b/src/components/product/ProductCardStyle.ts
@@ -62,11 +62,12 @@ export const imageStyle = css`
 	object-fit: cover;
 `;
 
-export const productInfoContainer = (hoverLarge: boolean) => css`
+export const productInfoContainer = (width: string, hoverLarge: boolean) => css`
 	display: flex;
 	flex-direction: column;
 	gap: 0.8rem;
 	${!hoverLarge && `padding: 0 1.6rem;`}
+	width: ${width};
 `;
 
 export const productInfoWrapper = css`
@@ -76,8 +77,12 @@ export const productInfoWrapper = css`
 `;
 
 export const productNameStyle = (theme: Theme) => css`
+	overflow: hidden;
+
 	${theme.fonts.eng.bodyMedium13};
 	color: ${theme.colors.gray9};
+	white-space: nowrap;
+	text-overflow: ellipsis;
 `;
 
 export const priceContainer = css`


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 관련 이슈 🛰️
> 해결한 이슈 번호를 작성해주세요
close #74 

## 작업 내용 🧑‍💻
> 작업한 내용을 간략히 작성해주세요
<!-- 예시:
- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 로그아웃 기능 구현 및 UI 수정
-->
- 다른 상품 추천 부분에서 상품 컴포넌트의 크기가 달라져서 가로 길이를 props로 받도록 수정했습니다
- 기존에는 호버 시 (like 테두리 여백이 생기도록) transform 되도록 구성되어있었는데, `hoverLarge`도 추가하여 상황에 따라 호버 시 transform 없이 아래 여백만 생길 수 있도록 수정하였습니다
- 다른 상품 추천 부분에서는 상품 내용이 기본적으로 양옆 패딩이 들어가 있어서 이 부분도 상황에 따라 반영할 수 있도록 수정하였습니다
- 기존에는 `별점 -> 가격` 순서였는데, 다른 상품 추천 부분에서는 `가격 -> 별점` 순으로 디자인 되어있는데요, 상황에 따라 순서를 다르게 처리해 줄 수는 있지만 불필요하다고 생각되어 생략했습니다🥲🙏

## PR 포인트 🗯️
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 더 좋은 방향성이 있다면 적극 반영하겠습니다!

## 알게된 점 🚀
> 기록하며 개발하기!
<!-- 예시:
- React Query의 staleTime 설정 방법
-->
- `text-overflow : ellipsis`는 잘라지는 부분에 말줄임표(...)를 붙여준다.

## 참고 자료 📖 (선택)
> 참고했던 문서들 공유하기!
<!-- 예시:
- React Query의 staleTime 설정 방법 : https://velog.io/@oimne/React-Query-staleTime%EA%B3%BC-cacheTime-%EB%8B%A4%EB%A3%A8%EA%B8%B0
-->
- 


## 스크린샷 📸 (선택)
<!-- 작업한 내용의 스크린샷을 첨부하고 싶다면 작성하세요 -->
- 기존

https://github.com/user-attachments/assets/77797dfa-69f9-4b7e-843f-d97c7e030bbb



- 변경


https://github.com/user-attachments/assets/594c956a-f42d-4680-884e-62b46d3366ae

- 말줄임표(...) 추가


https://github.com/user-attachments/assets/b248c708-f5ea-4c4b-9fb3-59862462427a

