### PR TITLE
[FEAT] 주문 완료 api

### DIFF
--- a/src/apis/productPage/order/orderProduct.ts
+++ b/src/apis/productPage/order/orderProduct.ts
@@ -1,0 +1,11 @@
+import instance from '@apis/instance';
+
+const fetchOrderProduct = async (productId: number) => {
+	const response = await instance.post(`/api/order`, {
+		productId,
+	});
+
+	return response.data;
+};
+
+export default fetchOrderProduct;

--- a/src/apis/productPage/order/orderQuery.ts
+++ b/src/apis/productPage/order/orderQuery.ts
@@ -1,0 +1,15 @@
+import fetchOrderProduct from '@apis/productPage/order/orderProduct';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+const useOrderProduct = () => {
+	const queryClient = useQueryClient();
+
+	const mutation = useMutation({
+		mutationFn: (productId: number) => fetchOrderProduct(productId),
+		onSuccess: () => queryClient.invalidateQueries({ queryKey: ['order'] }),
+	});
+
+	return { mutate: mutation.mutate };
+};
+
+export default useOrderProduct;

--- a/src/assets/icons/ic_dot.svg
+++ b/src/assets/icons/ic_dot.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="2" height="2" viewBox="0 0 2 2" fill="none">
+  <circle cx="1" cy="1" r="1" fill="black"/>
+</svg>

--- a/src/assets/icons/index.ts
+++ b/src/assets/icons/index.ts
@@ -140,3 +140,4 @@ export { default as ImgLine } from '../images/Line 18.svg';
 export { default as ImgVector7192 } from '../images/Vector 7192.svg';
 export { default as ImgProfile30 } from '../images/img_profile_30.svg';
 export { default as ImgGraph } from '@assets/images/img_graph.svg';
+export { default as IcDot } from './ic_dot.svg';

--- a/src/components/ProductInfo/ProductInfo.tsx
+++ b/src/components/ProductInfo/ProductInfo.tsx
@@ -1,7 +1,8 @@
-import { IcInfoGray14, IcWarningBrandYellow16 } from '@assets/icons';
+import { IcInfoGray14, IcWarningBrandYellow16, IcDot } from '@assets/icons';
 import bannerRewordImg from '@assets/images/img_banner_reward.png';
 import productSubImg1 from '@assets/images/img_product_sub1.png';
 import { productOptionImages, productSubImages } from '@assets/images/productDetailImages';
+import StarBtn from '@components/button/starBtn/StarBtn';
 import {
 	productInfoContainerStyle,
 	proudctImgLayoutStyle,
@@ -25,6 +26,7 @@ import {
 	endSaleTiemStyle,
 	reviewBoxStyle,
 	columnflexStyle,
+	reivewBoxStyle,
 } from '@components/ProductInfo/ProductInfoStyle';
 
 const ProductInfo = () => (
@@ -55,7 +57,11 @@ const ProductInfo = () => (
 						67W
 					</div>
 				</div>
-				<div css={reviewBoxStyle}>5,000+개 판매</div>
+				<div css={reivewBoxStyle}>
+					<StarBtn rating={4.8} reviewCount={123} />
+					<IcDot />
+					<div css={reviewBoxStyle}>5,000+개 판매</div>
+				</div>
 				<div css={mediumDividerStyle} />
 				<div css={optionStyle}>색상: 검정</div>
 				<section css={optionImgStyle}>

--- a/src/components/ProductInfo/ProductInfoStyle.ts
+++ b/src/components/ProductInfo/ProductInfoStyle.ts
@@ -103,6 +103,8 @@ export const productNameStyle = (theme: Theme) => css`
 `;
 
 export const reviewBoxStyle = (theme: Theme) => css`
+	display: flex;
+	align-items: center;
 	width: 100%;
 	height: 2rem;
 
@@ -170,3 +172,11 @@ export const columnflexStyle = css`
 	display: flex;
 	flex-direction: column;
 `;
+
+export const reivewBoxStyle = css`
+	display: flex;
+	gap: 0.6rem;
+	align-items: center;
+	height: 2rem;
+`;
+

--- a/src/components/button/starBtn/StarBtnStyle.ts
+++ b/src/components/button/starBtn/StarBtnStyle.ts
@@ -1,13 +1,17 @@
 import { css, Theme } from '@emotion/react';
 
-export const starBtnContainerStyle = css`
+const flexBoxStyle = css`
 	display: flex;
 	align-items: center;
-	width: 11.5rem;
 	height: 2rem;
+`;
+
+export const starBtnContainerStyle = css`
+	width: 11.5rem;
 
 	background-color: transparent;
 	border: none;
+	${flexBoxStyle}
 `;
 
 export const startIconBoxStyle = css`
@@ -20,10 +24,12 @@ export const ratingStyle = (theme: Theme) => css`
 	margin-left: 0.6rem;
 
 	${theme.fonts.eng.captionBold11};
+	${flexBoxStyle}
 `;
 
 export const reviewCountSTyle = (theme: Theme) => css`
 	margin-left: 0.4rem;
 
+	${flexBoxStyle}
 	${theme.fonts.eng.captionMedium12};
 `;

--- a/src/components/orderBox/OrderBox.tsx
+++ b/src/components/orderBox/OrderBox.tsx
@@ -1,3 +1,4 @@
+import useOrderProduct from '@apis/productPage/order/orderQuery';
 import {
 	IcMapBlackStorke18,
 	IcDeliveryBlack20,
@@ -32,68 +33,87 @@ import {
 	orderBtnWrapperStyle,
 	emojiBtnWrapperStyle,
 } from '@components/orderBox/OrderboxStyle';
+import { useNavigate } from 'react-router-dom';
 
-const OrderBox = () => (
-	<article css={orderBoxContinerStyle}>
-		<section css={orderInfoLayoutStyle}>
-			<div css={orderTitleWrapperStyle}>
-				<p css={korTitleStyle}>배송지:</p>
-				<div css={adressStyle}>
-					<IcMapBlackStorke18 />
-					<p>Gangnam-gu, Seoul, Korea</p>
+const OrderBox = () => {
+	const navigate = useNavigate();
+	const { mutate: orderProduct } = useOrderProduct();
+
+	const handleOrderBtnClick = (productId: number) => {
+		orderProduct(productId, {
+			onSuccess: (response) => {
+				if (response.success) {
+					navigate('/order');
+				}
+			},
+			onError: (error) => {
+				console.error(error);
+			},
+		});
+	};
+
+	return (
+		<article css={orderBoxContinerStyle}>
+			<section css={orderInfoLayoutStyle}>
+				<div css={orderTitleWrapperStyle}>
+					<p css={korTitleStyle}>배송지:</p>
+					<div css={adressStyle}>
+						<IcMapBlackStorke18 />
+						<p>Gangnam-gu, Seoul, Korea</p>
+					</div>
 				</div>
-			</div>
-			<div css={dividerStyle} />
-			<section css={orderInfoLayouttyle}>
-				<div>
-					<div css={freeOrderInfoWrapperStyle}>
-						<div css={flexBoxStyle}>
-							<IcDeliveryBlack20 />
-							<span css={korTitleStyle}>무료 배송</span>
-							{/* 영경이가 만든 무료 반품 버튼 넣기 */}
+				<div css={dividerStyle} />
+				<section css={orderInfoLayouttyle}>
+					<div>
+						<div css={freeOrderInfoWrapperStyle}>
+							<div css={flexBoxStyle}>
+								<IcDeliveryBlack20 />
+								<span css={korTitleStyle}>무료 배송</span>
+								{/* 영경이가 만든 무료 반품 버튼 넣기 */}
+							</div>
+							<IcArrowrightSBlack24 />
 						</div>
-						<IcArrowrightSBlack24 />
+						<div css={arrivalDateWrapperStyle}>
+							<span css={arriveTitleStyle}>도착일:</span>
+							<span css={engTitleStyle}>11 월 19 일-26 일</span>
+						</div>
 					</div>
-					<div css={arrivalDateWrapperStyle}>
-						<span css={arriveTitleStyle}>도착일:</span>
-						<span css={engTitleStyle}>11 월 19 일-26 일</span>
+					<div css={privacyInfoLayoutStyle}>
+						<div css={privacyTitleBoxStyle}>
+							<IcShieldBlack20 />
+							<span css={korTitleStyle}>개인 정보 보호</span>
+						</div>
+						<div css={descriptionBoxStyle}>
+							<p>안심 결제: 카드 정보는 안전하게 보호되며 유출되지 않습니다.</p>
+							<p>개인정보 보호: 개인정보 보안을 최우선으로 생각합니다.</p>
+						</div>
 					</div>
-				</div>
-				<div css={privacyInfoLayoutStyle}>
-					<div css={privacyTitleBoxStyle}>
-						<IcShieldBlack20 />
-						<span css={korTitleStyle}>개인 정보 보호</span>
-					</div>
-					<div css={descriptionBoxStyle}>
-						<p>안심 결제: 카드 정보는 안전하게 보호되며 유출되지 않습니다.</p>
-						<p>개인정보 보호: 개인정보 보안을 최우선으로 생각합니다.</p>
-					</div>
-				</div>
+				</section>
 			</section>
-		</section>
-		<div css={dividerStyle} />
-		<section css={orderButtonsLayoutStyle}>
-			<div css={korTitleStyle}>수량</div>
-			<section css={countButtonsStyle}>
-				<div css={iconWrapperStyle}>
-					<IcCountdownGray18 />
-				</div>
-				<p css={engCaptionBoldStyle}>1</p>
-				<div css={iconWrapperStyle}>
-					<IcCountupGray18 />
-				</div>
+			<div css={dividerStyle} />
+			<section css={orderButtonsLayoutStyle}>
+				<div css={korTitleStyle}>수량</div>
+				<section css={countButtonsStyle}>
+					<div css={iconWrapperStyle}>
+						<IcCountdownGray18 />
+					</div>
+					<p css={engCaptionBoldStyle}>1</p>
+					<div css={iconWrapperStyle}>
+						<IcCountupGray18 />
+					</div>
+				</section>
+				<section css={orderBtnWrapperStyle}>
+					<TextBtn btnText="바로 구매" color="red" size="large" onClick={() => handleOrderBtnClick(1)} />
+					<TextBtn btnText="장바구니 담기" color="black" size="large" />
+					<div css={emojiBtnWrapperStyle}>
+						<EmojiBtn type="seller" />
+						<EmojiBtn type="share" />
+						<LikeBtn />
+					</div>
+				</section>
 			</section>
-			<section css={orderBtnWrapperStyle}>
-				<TextBtn btnText="바로 구매" color="red" size="large" />
-				<TextBtn btnText="장바구니 담기" color="black" size="large" />
-				<div css={emojiBtnWrapperStyle}>
-					<EmojiBtn type="seller" />
-					<EmojiBtn type="share" />
-					<LikeBtn />
-				</div>
-			</section>
-		</section>
-	</article>
-);
+		</article>
+	);
+};
 
 export default OrderBox;

--- a/src/components/orderBox/OrderBox.tsx
+++ b/src/components/orderBox/OrderBox.tsx
@@ -32,7 +32,9 @@ import {
 	engCaptionBoldStyle,
 	orderBtnWrapperStyle,
 	emojiBtnWrapperStyle,
+	freeDeliveryText,
 } from '@components/orderBox/OrderboxStyle';
+import FreeTag from '@components/product/FreeTag';
 import { useNavigate } from 'react-router-dom';
 
 const OrderBox = () => {
@@ -68,8 +70,8 @@ const OrderBox = () => {
 						<div css={freeOrderInfoWrapperStyle}>
 							<div css={flexBoxStyle}>
 								<IcDeliveryBlack20 />
-								<span css={korTitleStyle}>무료 배송</span>
-								{/* 영경이가 만든 무료 반품 버튼 넣기 */}
+								<span css={freeDeliveryText}>무료 배송</span>
+								<FreeTag text="무료 반품" color="gray" />
 							</div>
 							<IcArrowrightSBlack24 />
 						</div>

--- a/src/components/orderBox/OrderboxStyle.ts
+++ b/src/components/orderBox/OrderboxStyle.ts
@@ -40,6 +40,11 @@ export const korTitleStyle = (theme: Theme) => css`
 	${theme.fonts.kor.captionBold12}
 `;
 
+export const freeDeliveryText = (theme: Theme) => css`
+	margin-right: 0.6rem;
+	${theme.fonts.kor.captionBold12}
+`;
+
 export const engTitleStyle = (theme: Theme) => css`
 	${theme.fonts.eng.captionMedium12}
 `;
@@ -70,7 +75,7 @@ export const freeOrderInfoWrapperStyle = css`
 export const flexBoxStyle = css`
 	display: flex;
 	align-items: center;
-	height: 100%;
+	height: 2rem;
 `;
 
 export const arrivalDateWrapperStyle = css`

--- a/src/components/recommandedProducts/RecommandedBoxStyle.ts
+++ b/src/components/recommandedProducts/RecommandedBoxStyle.ts
@@ -10,6 +10,7 @@ export const recommandedBoxContainer = (theme: Theme) => css`
 	padding: 1rem 1.8rem;
 
 	background-color: ${theme.colors.brandBg};
+	border-radius: 8px;
 `;
 
 export const contentLayout = css`
@@ -46,4 +47,5 @@ export const lineStyle = (theme: Theme) => css`
 export const flexBoxStyle = css`
 	display: flex;
 	gap: 0.8rem;
+	width: 32rem;
 `;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 관련 이슈 🛰️
> 해결한 이슈 번호를 작성해주세요
close #90

## 작업 내용 🧑‍💻
> 작업한 내용을 간략히 작성해주세요
<!-- 예시:
- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 로그아웃 기능 구현 및 UI 수정
-->
- 상품 주문을 처리하는  useOrderProduct 커스텀 훅을 구현하였습니다.
- 주문이 성공하면 (success의 값이 true이면) order 페이지로 이동하도록 하엿씁니다.
- 상품 주문은 post 메서드이기 때문에 useMutation를 사용해서 훅을 구현하였습니다.
- 이전에 퍼블리싱을 하면서 별점 버튼과 무료 반품 버튼을 추가하지 않았어서 해당 부분을 추가하였습니다.
- 추천 상점의 퍼블리싱이 약간 잘못된 부분이 있어서 그것도 같이 수정햇슴니다 ,,ㅎㅎ


## PR 포인트 🗯️
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- api만 추가한게 아니라 퍼블리싱 수정까지 같은 브랜치에서 해서 죄송해요!!!!!!

## 알게된 점 🚀
> 기록하며 개발하기!
<!-- 예시:
- React Query의 staleTime 설정 방법
-->
- 

## 참고 자료 📖 (선택)
> 참고했던 문서들 공유하기!
<!-- 예시:
- React Query의 staleTime 설정 방법 : https://velog.io/@oimne/React-Query-staleTime%EA%B3%BC-cacheTime-%EB%8B%A4%EB%A3%A8%EA%B8%B0
-->
- 


## 스크린샷 📸 (선택)
<!-- 작업한 내용의 스크린샷을 첨부하고 싶다면 작성하세요 -->
![Nov-29-2024 03-00-05](https://github.com/user-attachments/assets/fbea4aad-5726-425e-8954-6a53fd6005e1)

- 해당 부분의 title이 밑으로 내려가 있어서 조정
<img width="1306" alt="image" src="https://github.com/user-attachments/assets/1451f97a-5a1e-4614-9bea-2bc99aa714de">

- 무료 반품 버튼 추가 안했어서 추가
<img width="180" alt="image" src="https://github.com/user-attachments/assets/5d3019b6-7eaa-4e79-a12d-b0d80f4afe8e">
