### PR TITLE
[FIX] 뷰 피그마에 맞게 수정

### DIFF
--- a/src/components/footer/FooterStyle.ts
+++ b/src/components/footer/FooterStyle.ts
@@ -25,9 +25,15 @@ export const footerStyle = (theme: Theme) => css`
 `;
 
 export const subtitleStyle = (theme: Theme) => css`
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+
 	${theme.fonts.kor.bodyBold13}
+	color: ${theme.colors.gray10};
 `;
 
 export const desc = (theme: Theme) => css`
 	${theme.fonts.kor.captionMedium11};
+	color: ${theme.colors.gray7};
 `;

--- a/src/components/header/productHeader/CategoryStyle.ts
+++ b/src/components/header/productHeader/CategoryStyle.ts
@@ -9,6 +9,12 @@ export const CategoryLayout = css`
 	gap: 0;
 	align-items: center;
 	justify-content: center;
+
+	box-shadow:
+		0 0.6rem 1.2rem 0 rgb(0 0 0 / 12%),
+		0 0.4rem 0.8rem 0 rgb(0 0 0 / 8%),
+		0 0 0.4rem 0 rgb(0 0 0 / 8%);
+	border-radius: 12px;
 `;
 
 export const CategoryContainerStyle = (theme: Theme) => css`

--- a/src/components/header/productHeader/MyListStyle.ts
+++ b/src/components/header/productHeader/MyListStyle.ts
@@ -9,6 +9,12 @@ export const MyLayoutStyle = css`
 	gap: 0;
 	align-items: center;
 	justify-content: center;
+
+	box-shadow:
+		0 0.6rem 1.2rem 0 rgb(0 0 0 / 12%),
+		0 0.4rem 0.8rem 0 rgb(0 0 0 / 8%),
+		0 0 0.4rem 0 rgb(0 0 0 / 8%);
+	border-radius: 12px;
 `;
 
 export const MyContainerStyle = (theme: Theme) => css`

--- a/src/components/productPage/review/review/FilterBtn.tsx
+++ b/src/components/productPage/review/review/FilterBtn.tsx
@@ -1,5 +1,6 @@
 import { IcArrowbottomGray12 } from '@assets/icons/index';
 import {
+	relativeStyle,
 	fontStyle,
 	FilterBtnContainer,
 	dropDownLayoutStyle,
@@ -11,7 +12,7 @@ const FilterBtn = () => {
 	const [isHovered, setIsHovered] = useState(false);
 
 	return (
-		<div css={fontStyle}>
+		<div css={[fontStyle, relativeStyle]}>
 			<div css={FilterBtnContainer} onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)}>
 				<p>최근 작성된 리뷰</p>
 				<IcArrowbottomGray12 />

--- a/src/components/productPage/review/review/FilterBtnStyle.ts
+++ b/src/components/productPage/review/review/FilterBtnStyle.ts
@@ -1,7 +1,10 @@
 import { Theme, css } from '@emotion/react';
 
-export const FilterBtnContainer = (theme: Theme) => css`
+export const relativeStyle = css`
 	position: relative;
+`;
+
+export const FilterBtnContainer = (theme: Theme) => css`
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
@@ -20,7 +23,7 @@ export const fontStyle = (theme: Theme) => css`
 
 export const dropDownLayoutStyle = (theme: Theme) => css`
 	position: absolute;
-	top: 5rem;
+	top: 3.2rem;
 	width: 15.4rem;
 
 	background-color: ${theme.colors.gray1};

--- a/src/components/productPage/review/reviewTop/Title.tsx
+++ b/src/components/productPage/review/reviewTop/Title.tsx
@@ -4,7 +4,6 @@ import {
 	titleContainer,
 	fontKoStyle,
 	fontEnStyle,
-	alignStyle,
 	toolStyle,
 } from '@components/productPage/review/reviewTop/TitleStyle';
 import { useState } from 'react';
@@ -20,7 +19,7 @@ const Title = () => {
 		<div css={[titleContainer, relativeStyle]}>
 			<p css={fontKoStyle}>리뷰</p>
 			<p css={fontEnStyle}>(497)</p>
-			<IcHelpGray20 css={alignStyle} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave} />
+			<IcHelpGray20 onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave} />
 			{isHovered && <div css={toolStyle}>{TOOL_MSG}</div>}
 		</div>
 	);

--- a/src/components/productPage/review/reviewTop/TitleStyle.ts
+++ b/src/components/productPage/review/reviewTop/TitleStyle.ts
@@ -19,11 +19,6 @@ export const fontEnStyle = (theme: Theme) => css`
 	${theme.fonts.eng.titleBold20}
 `;
 
-export const alignStyle = css`
-	margin-top: 0.2rem;
-
-	cursor: pointer;
-`;
 export const toolStyle = (theme: Theme) => css`
 	position: absolute;
 	top: 2.8rem;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 관련 이슈 🛰️
> 해결한 이슈 번호를 작성해주세요
close #95 

## 작업 내용 🧑‍💻
> 작업한 내용을 간략히 작성해주세요
<!-- 예시:
- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 로그아웃 기능 구현 및 UI 수정
-->
피그마 뷰와 안맞는 요소가 몇 개 있어 반영했습니다!
- 헤더 드롭다운 그림자 적용
- 푸터 글자 간격 및 색상 적용
- 최근 작성된 리뷰 버튼 드롭다운 위치 조정


## 스크린샷 📸 (선택)
- 드롭다운 동영상

https://github.com/user-attachments/assets/834553aa-5032-4664-b32c-cd485c914b77

- 푸터 글자간격 

<img width="1470" alt="스크린샷 2024-11-29 오전 4 24 06" src="https://github.com/user-attachments/assets/ca5b04a8-64da-4b2d-8d42-1b8bdd54c7d5">
