### PR TITLE
[FEAT] 주문내역 api 연결

### DIFF
--- a/src/apis/orderPage/getOrders.ts
+++ b/src/apis/orderPage/getOrders.ts
@@ -1,11 +1,22 @@
-import { useQuery } from '@tanstack/react-query';
+import instance from '@apis/instance';
 
-import fetchOrders from './orderQueries';
+interface OrderResponse {
+	productId: number;
+	productImage: string;
+	detail: string;
+	price: number;
+	quantity: number;
+}
 
-const useOrders = (productId: number) =>
-	useQuery({
-		queryKey: ['orders', productId],
-		queryFn: () => fetchOrders(),
-	});
+interface OrderHistoryResponse {
+	success: boolean;
+	data: OrderResponse;
+	error: string | null;
+}
 
-export default useOrders;
+const fetchOrders = async (): Promise<OrderHistoryResponse> => {
+	const response = await instance.get<OrderHistoryResponse>(`/api/orders`);
+	return response.data;
+};
+
+export default fetchOrders;

--- a/src/apis/orderPage/getOrders.ts
+++ b/src/apis/orderPage/getOrders.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+
+import fetchOrders from './orderQueries';
+
+const useOrders = (productId: number) =>
+	useQuery({
+		queryKey: ['orders', productId],
+		queryFn: () => fetchOrders(),
+	});
+
+export default useOrders;

--- a/src/apis/orderPage/orderQueries.ts
+++ b/src/apis/orderPage/orderQueries.ts
@@ -1,0 +1,22 @@
+import instance from '@apis/instance';
+
+interface OrderResponse {
+	productId: number;
+	productImage: string;
+	detail: string;
+	price: number;
+	quantity: number;
+}
+
+interface RelatedOrderResponse {
+	success: boolean;
+	data: OrderResponse[];
+	error: string | null;
+}
+
+const fetchRelatedOrders = async (): Promise<OrderResponse[]> => {
+	const response = await instance.get<RelatedOrderResponse>(`/api/orders`);
+	return response.data.data;
+};
+
+export default fetchRelatedOrders;

--- a/src/apis/orderPage/orderQueries.ts
+++ b/src/apis/orderPage/orderQueries.ts
@@ -1,4 +1,5 @@
 import instance from '@apis/instance';
+import { AxiosError } from 'axios';
 
 interface OrderResponse {
 	productId: number;
@@ -8,15 +9,22 @@ interface OrderResponse {
 	quantity: number;
 }
 
-interface RelatedOrderResponse {
+interface OrderHistoryResponse {
 	success: boolean;
 	data: OrderResponse[];
 	error: string | null;
 }
 
-const fetchRelatedOrders = async (): Promise<OrderResponse[]> => {
-	const response = await instance.get<RelatedOrderResponse>(`/api/orders`);
-	return response.data.data;
+const fetchOrders = async (): Promise<OrderResponse[]> => {
+	try {
+		const response = await instance.get<OrderHistoryResponse>(`/api/orders`);
+		return response.data.data;
+	} catch (error) {
+		if (error instanceof AxiosError) {
+			throw error.response?.data || new Error('An error occurred');
+		}
+		throw error;
+	}
 };
 
-export default fetchRelatedOrders;
+export default fetchOrders;

--- a/src/apis/orderPage/orderQueries.ts
+++ b/src/apis/orderPage/orderQueries.ts
@@ -1,30 +1,13 @@
-import instance from '@apis/instance';
-import { AxiosError } from 'axios';
+import dummpyOrderHistory from '@constants/dummyOrderHistory';
+import { useQuery } from '@tanstack/react-query';
 
-interface OrderResponse {
-	productId: number;
-	productImage: string;
-	detail: string;
-	price: number;
-	quantity: number;
-}
+import fetchOrders from './getOrders';
 
-interface OrderHistoryResponse {
-	success: boolean;
-	data: OrderResponse[];
-	error: string | null;
-}
+const useOrders = () =>
+	useQuery({
+		queryKey: ['orders'],
+		queryFn: () => fetchOrders(),
+		initialData: dummpyOrderHistory,
+	});
 
-const fetchOrders = async (): Promise<OrderResponse[]> => {
-	try {
-		const response = await instance.get<OrderHistoryResponse>(`/api/orders`);
-		return response.data.data;
-	} catch (error) {
-		if (error instanceof AxiosError) {
-			throw error.response?.data || new Error('An error occurred');
-		}
-		throw error;
-	}
-};
-
-export default fetchOrders;
+export default useOrders;

--- a/src/apis/orderPage/orderQueries.ts
+++ b/src/apis/orderPage/orderQueries.ts
@@ -7,7 +7,6 @@ const useOrders = () =>
 	useQuery({
 		queryKey: ['orders'],
 		queryFn: () => fetchOrders(),
-		initialData: dummpyOrderHistory,
 	});
 
 export default useOrders;

--- a/src/apis/orderPage/orderQueries.ts
+++ b/src/apis/orderPage/orderQueries.ts
@@ -1,4 +1,3 @@
-import dummpyOrderHistory from '@constants/dummyOrderHistory';
 import { useQuery } from '@tanstack/react-query';
 
 import fetchOrders from './getOrders';

--- a/src/components/orderDetail/orderHistory/orderHistory.tsx
+++ b/src/components/orderDetail/orderHistory/orderHistory.tsx
@@ -1,7 +1,9 @@
+import useOrders from '@apis/orderPage/orderQueries';
 import { IcArrowrightGray12, IcChatBlack24, IcArrowbottomGray12, IcCameraBlack24 } from '@assets/icons';
-import productImage from '@assets/images/img_purchasedproduct_113.png';
 import OutlineTextBtn from '@components/button/outlineTextBtn/OutlineTextBtn';
-import ORDER_HISTORYT from '@constants/orderHisotry';
+import MESSAGE from '@constants/errorMessages';
+import { AxiosError } from 'axios';
+
 import {
 	orderHistoryContainerStyle,
 	headerStyle,
@@ -23,50 +25,64 @@ import {
 	costBoldLabelStyle,
 } from './orderHistoryStyle';
 
-const OrderHistory = () => (
-	<div css={orderHistoryContainerStyle}>
-		<header css={headerStyle}>주문 내역</header>
-		<div css={storeNameContainerStyle}>
-			<p css={storeNameStyle}>Toocki Flagship Direct store</p>
-			<IcArrowrightGray12 />
-			<IcChatBlack24 />
-		</div>
-		<div css={productContentStyle}>
-			<div css={productImageStyle}>
-				<img src={productImage} alt="상품 이미지" />
-				<IcCameraBlack24 />
+const OrderHistory = () => {
+	const { data, error } = useOrders();
+
+	if (!data) {
+		return null;
+	}
+
+	if (error) {
+		const axiosError = error as AxiosError<{ error: { message: string } }>;
+		const errorMessage = axiosError.response?.data?.error?.message || MESSAGE.UNKNOWN_ERROR;
+		console.log(errorMessage);
+	}
+
+	return (
+		<div css={orderHistoryContainerStyle}>
+			<header css={headerStyle}>주문 내역</header>
+			<div css={storeNameContainerStyle}>
+				<p css={storeNameStyle}>Toocki Flagship Direct store</p>
+				<IcArrowrightGray12 />
+				<IcChatBlack24 />
 			</div>
-			<div css={productInfoContainerStyle}>
-				<div css={productInfoStyle}>
-					<p css={productTitleStyle}>{ORDER_HISTORYT.detail}</p>
-					<p>Clear</p>
-					<div css={productPriceStyle}>
-						<p>￦{ORDER_HISTORYT.price.toLocaleString()}</p>
-						<p>x{ORDER_HISTORYT.quantity}</p>
+			<div css={productContentStyle}>
+				<div css={productImageStyle}>
+					<img src={data.data.productImage} alt="상품 이미지" />
+					<IcCameraBlack24 />
+				</div>
+				<div css={productInfoContainerStyle}>
+					<div css={productInfoStyle}>
+						<p css={productTitleStyle}>{data.data.detail}</p>
+						<p>Clear</p>
+						<div css={productPriceStyle}>
+							<p>￦{data.data.price.toLocaleString()}</p>
+							<p>x{data.data.quantity}</p>
+						</div>
+					</div>
+					<p css={blueInfoStyle}>빠른 배송 · 무료 반품 · 배송 약속</p>
+				</div>
+				<div css={buttonContainerStyle}>
+					<OutlineTextBtn btnText="장바구니에 담기" size="medium" />
+					<OutlineTextBtn btnText="환불/반품" size="medium" />
+					<OutlineTextBtn btnText="영수증 보기" size="medium" />
+				</div>
+			</div>
+			<div css={productCostStyle}>
+				<div css={costRowStyle}>
+					<p css={costGrayLabelStyle}>합계</p>
+					<div css={costValueStyle}>
+						<p>￦{(data.data.price * data.data.quantity).toLocaleString()}</p>
+						<IcArrowbottomGray12 />
 					</div>
 				</div>
-				<p css={blueInfoStyle}>빠른 배송 · 무료 반품 · 배송 약속</p>
-			</div>
-			<div css={buttonContainerStyle}>
-				<OutlineTextBtn btnText="장바구니에 담기" size="medium" />
-				<OutlineTextBtn btnText="환불/반품" size="medium" />
-				<OutlineTextBtn btnText="영수증 보기" size="medium" />
-			</div>
-		</div>
-		<div css={productCostStyle}>
-			<div css={costRowStyle}>
-				<p css={costGrayLabelStyle}>합계</p>
-				<div css={costValueStyle}>
-					<p>￦{ORDER_HISTORYT.price.toLocaleString()}</p>
-					<IcArrowbottomGray12 />
+				<div css={costRowStyle}>
+					<p css={costLabelStyle}>총 금액</p>
+					<p css={costBoldLabelStyle}>￦230,202</p>
 				</div>
 			</div>
-			<div css={costRowStyle}>
-				<p css={costLabelStyle}>총 금액</p>
-				<p css={costBoldLabelStyle}>￦1,202</p>
-			</div>
 		</div>
-	</div>
-);
+	);
+};
 
 export default OrderHistory;

--- a/src/components/orderDetail/orderHistory/orderHistory.tsx
+++ b/src/components/orderDetail/orderHistory/orderHistory.tsx
@@ -3,6 +3,7 @@ import { IcArrowrightGray12, IcChatBlack24, IcArrowbottomGray12, IcCameraBlack24
 import OutlineTextBtn from '@components/button/outlineTextBtn/OutlineTextBtn';
 import MESSAGE from '@constants/errorMessages';
 import { AxiosError } from 'axios';
+import { useNavigate } from 'react-router-dom';
 
 import {
 	orderHistoryContainerStyle,
@@ -27,16 +28,17 @@ import {
 
 const OrderHistory = () => {
 	const { data, error } = useOrders();
-
-	if (!data) {
-		return null;
-	}
+	const navigate = useNavigate();
 
 	if (error) {
 		const axiosError = error as AxiosError<{ error: { message: string } }>;
 		const errorMessage = axiosError.response?.data?.error?.message || MESSAGE.UNKNOWN_ERROR;
 		console.log(errorMessage);
 	}
+
+	const handleProductTitleClick = () => {
+		navigate('/');
+	};
 
 	return (
 		<div css={orderHistoryContainerStyle}>
@@ -53,7 +55,9 @@ const OrderHistory = () => {
 				</div>
 				<div css={productInfoContainerStyle}>
 					<div css={productInfoStyle}>
-						<p css={productTitleStyle}>{data.data.detail}</p>
+						<p css={productTitleStyle} onClick={handleProductTitleClick}>
+							{data.data.detail}
+						</p>
 						<p>Clear</p>
 						<div css={productPriceStyle}>
 							<p>￦{data.data.price.toLocaleString()}</p>

--- a/src/components/orderDetail/orderHistory/orderHistory.tsx
+++ b/src/components/orderDetail/orderHistory/orderHistory.tsx
@@ -50,18 +50,18 @@ const OrderHistory = () => {
 			</div>
 			<div css={productContentStyle}>
 				<div css={productImageStyle}>
-					<img src={data.data.productImage} alt="상품 이미지" />
+					<img src={data?.data.productImage} alt="상품 이미지" />
 					<IcCameraBlack24 />
 				</div>
 				<div css={productInfoContainerStyle}>
 					<div css={productInfoStyle}>
 						<p css={productTitleStyle} onClick={handleProductTitleClick}>
-							{data.data.detail}
+							{data?.data.detail}
 						</p>
 						<p>Clear</p>
 						<div css={productPriceStyle}>
-							<p>￦{data.data.price.toLocaleString()}</p>
-							<p>x{data.data.quantity}</p>
+							<p>￦{data?.data.price.toLocaleString()}</p>
+							<p>x{data?.data.quantity}</p>
 						</div>
 					</div>
 					<p css={blueInfoStyle}>빠른 배송 · 무료 반품 · 배송 약속</p>
@@ -76,7 +76,7 @@ const OrderHistory = () => {
 				<div css={costRowStyle}>
 					<p css={costGrayLabelStyle}>합계</p>
 					<div css={costValueStyle}>
-						<p>￦{(data.data.price * data.data.quantity).toLocaleString()}</p>
+						<p>￦{(data?.data.price * data?.data.quantity).toLocaleString()}</p>
 						<IcArrowbottomGray12 />
 					</div>
 				</div>

--- a/src/components/orderDetail/orderHistory/orderHistory.tsx
+++ b/src/components/orderDetail/orderHistory/orderHistory.tsx
@@ -40,6 +40,8 @@ const OrderHistory = () => {
 		navigate('/');
 	};
 
+	const priceSum = (data?.data?.price ?? 0) * (data?.data?.quantity ?? 0);
+
 	return (
 		<div css={orderHistoryContainerStyle}>
 			<header css={headerStyle}>주문 내역</header>
@@ -76,7 +78,7 @@ const OrderHistory = () => {
 				<div css={costRowStyle}>
 					<p css={costGrayLabelStyle}>합계</p>
 					<div css={costValueStyle}>
-						<p>￦{(data?.data.price * data?.data.quantity).toLocaleString()}</p>
+						<p>￦{priceSum.toLocaleString()}</p>
 						<IcArrowbottomGray12 />
 					</div>
 				</div>

--- a/src/components/orderDetail/orderHistory/orderHistoryStyle.ts
+++ b/src/components/orderDetail/orderHistory/orderHistoryStyle.ts
@@ -39,6 +39,11 @@ export const productImageStyle = css`
 	position: relative;
 	margin-right: 1.4rem;
 
+	img {
+		width: 11.3rem;
+		height: 11.3rem;
+	}
+
 	svg {
 		position: absolute;
 		right: 0;

--- a/src/components/orderDetail/orderHistory/orderHistoryStyle.ts
+++ b/src/components/orderDetail/orderHistory/orderHistoryStyle.ts
@@ -74,6 +74,8 @@ export const productTitleStyle = (theme: Theme) => css`
 
 	white-space: nowrap;
 	text-overflow: ellipsis;
+
+	cursor: pointer;
 `;
 
 export const productPriceStyle = css`

--- a/src/constants/dummyOrderHistory.ts
+++ b/src/constants/dummyOrderHistory.ts
@@ -1,0 +1,14 @@
+const dummpyOrderHistory = {
+	success: true,
+	data: {
+		productId: 1,
+		productImage: 'https://ae01.alicdn.com/kf/S709d4d4778ea430c87c0bf0a6574fa8dz.jpg_220x220q75.jpg_.webp',
+		detail:
+			'Toocki C타입 to C타입 케이블, 100W PD 고속 충전 충전기, USB C to USB C 디스플레이 케이블, 샤오미 POCO F3 리얼미 맥북 아이패드용',
+		price: 2700,
+		quantity: 2,
+	},
+	error: null,
+};
+
+export default dummpyOrderHistory;

--- a/src/constants/orderHisotry.ts
+++ b/src/constants/orderHisotry.ts
@@ -1,8 +1,0 @@
-const ORDER_HISTORYT = {
-	detail:
-		'소프트 실리콘 충전기 케이블 와인더, 고속 충전 케이블 보호대 슬리브, 애플 아이폰 데이터 코드, 투명 케이스와 많이 사용되는 핸드폰',
-	price: 1358,
-	quantity: 1,
-} as const;
-
-export default ORDER_HISTORYT;


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 관련 이슈 🛰️
> 해결한 이슈 번호를 작성해주세요
close #93 

## 작업 내용 🧑‍💻
> 작업한 내용을 간략히 작성해주세요
<!-- 예시:
- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 로그아웃 기능 구현 및 UI 수정
-->
- 주문 배송 페이지 주문 내역 api 연결 완료했습니다.

## PR 포인트 🗯️
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
<!-- 예시:
- 특정 함수나 로직에 대한 의견 요청
-->
- 리드님의 많은 도움을 받았습니다 ㅠㅠ

## 알게된 점 🚀
> 기록하며 개발하기!
<!-- 예시:
- React Query의 staleTime 설정 방법
-->
- tanstack Query를 사용하여 api 연결을 해 볼 수 있었습닏.

## 참고 자료 📖 (선택)
> 참고했던 문서들 공유하기!
<!-- 예시:
- React Query의 staleTime 설정 방법 : https://velog.io/@oimne/React-Query-staleTime%EA%B3%BC-cacheTime-%EB%8B%A4%EB%A3%A8%EA%B8%B0
-->
- 


## 스크린샷 📸 (선택)
<!-- 작업한 내용의 스크린샷을 첨부하고 싶다면 작성하세요 -->
![image](https://github.com/user-attachments/assets/5a470485-ec4a-44aa-a969-ac37db707d30)